### PR TITLE
Only calling /shell if there is input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -60,11 +60,12 @@ def cli():
             raise KeyboardInterrupt
 
         def do_shell(self, line):
-            tokens = line.split(' ')
-            files = ['-F %s=@%s' % (token, token) for token in tokens if isfile(token)]
-            snippet = 'curl -X POST -H "X-Shell:%s" %s %s:9000/shell' % (line, ' '.join(files), ip)
-            code, out = self._exec(snippet)
-            print json.loads(out)['out'] if code is 0 else 'i/o failure (is the proxy down ?)'
+            if line:
+                tokens = line.split(' ')
+                files = ['-F %s=@%s' % (token, token) for token in tokens if isfile(token)]
+                snippet = 'curl -X POST -H "X-Shell:%s" %s %s:9000/shell' % (line, ' '.join(files), ip)
+                code, out = self._exec(snippet)
+                print json.loads(out)['out'] if code is 0 else 'i/o failure (is the proxy down ?)'
 
         def _exec(self, snippet):
             pid = Popen(snippet, shell=True, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
I was pressing enter since thats a typical thing to do in a shell and was seeing things that made me think that I wasn't connected to the session.

```
~/workspace/code/ochonetes (master ✘)✹✭ ᐅ ./cli.py ec2-52-24-24-192.us-west-2.compute.amazonaws.com
welcome to the ocho CLI ! (CTRL-C to exit)
ec2-52-24-24-192.us-west-2.compute.amazonaws.com >
unexpected failure -> ../datastructures.py (1278) -> KeyError ('HTTP_X_SHELL')
ec2-52-24-24-192.us-west-2.compute.amazonaws.com >
unexpected failure -> ../datastructures.py (1278) -> KeyError ('HTTP_X_SHELL')
ec2-52-24-24-192.us-west-2.compute.amazonaws.com >
unexpected failure -> ../datastructures.py (1278) -> KeyError ('HTTP_X_SHELL')
ec2-52-24-24-192.us-west-2.compute.amazonaws.com >
```
