### PR TITLE
Running apt-get update on its own line caused caching issues

### DIFF
--- a/images/portal/Dockerfile
+++ b/images/portal/Dockerfile
@@ -3,8 +3,7 @@ FROM paugamo/pod
 #
 # - add pip, pyyaml & reds
 #
-RUN apt-get update
-RUN apt-get -y install wget python-pip
+RUN apt-get update && apt-get -y install wget python-pip
 RUN pip install --no-use-wheel --upgrade distribute
 RUN pip install redis pyyaml
 


### PR DESCRIPTION
This occurs because the command is used to determine if the layer has been created already. In this case and update needs to be applied at roughly the same time as the install.

Reference: http://docs.docker.com/articles/dockerfile_best-practices/
