### PR TITLE
Added scripts to simplify proxy setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ coverage.xml
 docs/_build/
 
 .DS_Store
+
+ocho-proxy-*.yml.bak

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ $ cat ~/.kube/config
 
 #### Step 2 : deploy our proxy
 
-We use a simple proxy mechanism to interact with our containers. Edit the provided ```ocho-proxy.yml``` and specify
-the master IP (just the IP, not a URL) and user credentials. Then create the pod:
+We use a simple proxy mechanism to interact with our containers which is deployed as a pod. To create the pod use the included create-ocho-proxy script:
 
 ```
-$ kubernetes/cluster/kubectl.sh create -f ocho-proxy.yml
+$ ./create-ocho-proxy ~/workspace/kubernetes 52.11.127.120 admin d8f7d9s8f7sd9
 ```
 
 The _create_ will return immediately. Wait a bit until the pod is up and note the public IP it is running from. You

--- a/create-ocho-proxy
+++ b/create-ocho-proxy
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright (c) 2015 Autodesk Inc.
+# All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$#" -ne 4 ]; then
+    echo "usage: `basename "$0"` [KUBERNETES_DIR] [KUBERNETES_MASTER] [KUBERNETES_USER] [KUBERNETES_PWD]"
+    exit 1
+fi
+
+KUBERNETES_DIR=$1
+KUBERNETES_MASTER=$2
+KUBERNETES_USER=$3
+KUBERNETES_PWD=$4
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+export KUBERNETES_PROVIDER=aws
+
+# render ocho-proxy yml file
+OCHO_PROXY_TEMPLATE=$DIR/ocho-proxy.yml.template
+OCHO_PROXY_FILE=$DIR/ocho-proxy-$KUBERNETES_MASTER.yml.bak
+sed -e "s/{KUBERNETES_MASTER}/$KUBERNETES_MASTER/g" \
+    -e "s/{KUBERNETES_USER}/$KUBERNETES_USER/g" \
+    -e "s/{KUBERNETES_PWD}/$KUBERNETES_PWD/g" \
+    $OCHO_PROXY_TEMPLATE > $OCHO_PROXY_FILE
+
+# create pod
+$KUBERNETES_DIR/cluster/kubectl.sh create -f $OCHO_PROXY_FILE

--- a/delete-ocho-proxy
+++ b/delete-ocho-proxy
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2015 Autodesk Inc.
+# All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: `basename "$0"` [KUBERNETES_DIR]"
+    exit 1
+fi
+
+KUBERNETES_DIR=$1
+
+export KUBERNETES_PROVIDER=aws
+
+$KUBERNETES_DIR/cluster/kubectl.sh delete pod ocho-proxy

--- a/ocho-proxy.yml.template
+++ b/ocho-proxy.yml.template
@@ -20,13 +20,13 @@ spec:
         value:  "9001"
 
       - name:   KUBERNETES_MASTER
-        value:  <YOUR MASTER IP>
+        value:  {KUBERNETES_MASTER}
 
       - name:   KUBERNETES_USER
-        value:  <USER>
+        value:  {KUBERNETES_USER}
 
       - name:   KUBERNETES_PWD
-        value:  <PASSWORD>
+        value:  {KUBERNETES_PWD}
 
     #
     # - the web-shell listens on TCP 9000 and is bound to its host


### PR DESCRIPTION
- create-ocho-proxy accepts kubernetes dir, master, user, and password. Using these parameters it renders the ocho-proxy.yml.template and calls k8s to create the pod.
- delete-ochoproxy accepts kubernetes dir and calls k8s to delete the pod.

Small additions but I think they could be helpful.
